### PR TITLE
Add unit tests for core utilities

### DIFF
--- a/SIKCore/build.gradle
+++ b/SIKCore/build.gradle
@@ -43,6 +43,12 @@ android {
             version '3.22.1'
         }
     }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = false
+        }
+    }
 }
 
 dependencies {
@@ -67,4 +73,12 @@ dependencies {
     api("androidx.work:work-multiprocess:$work_version")
     //kotlin反射相关
     api("org.jetbrains.kotlin:kotlin-reflect:1.9.22")
+
+    // --- testing dependencies ---
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:1.8.20")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.8.20")
+    testImplementation("org.robolectric:robolectric:4.11.1")
+    testImplementation("io.mockk:mockk:1.13.5")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
 }

--- a/SIKCore/src/test/java/com/sik/sikcore/device/DeviceUtilsTest.kt
+++ b/SIKCore/src/test/java/com/sik/sikcore/device/DeviceUtilsTest.kt
@@ -1,0 +1,56 @@
+package com.sik.sikcore.device
+
+import android.os.Build
+import com.sik.sikcore.shell.ShellResult
+import com.sik.sikcore.shell.ShellUtils
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE)
+class DeviceUtilsTest {
+
+    private var originalTags: String? = null
+
+    @Before
+    fun setUp() {
+        originalTags = Build.TAGS
+    }
+
+    @After
+    fun tearDown() {
+        setBuildTags(originalTags)
+        unmockkAll()
+    }
+
+    private fun setBuildTags(value: String?) {
+        val field = Build::class.java.getDeclaredField("TAGS").apply { isAccessible = true }
+        field.set(null, value)
+    }
+
+    @Test
+    fun isDeviceRooted_falseByDefault() {
+        setBuildTags("release-keys")
+        mockkObject(ShellUtils) {
+            every { ShellUtils.execCmd(any(), any(), any()) } returns ShellResult(0, "", "")
+            assertFalse(DeviceUtils.isDeviceRooted())
+        }
+    }
+
+    @Test
+    fun isDeviceRooted_trueWhenTestKeys() {
+        setBuildTags("test-keys")
+        mockkObject(ShellUtils) {
+            every { ShellUtils.execCmd(any(), any(), any()) } returns ShellResult(0, "", "")
+            assertTrue(DeviceUtils.isDeviceRooted())
+        }
+    }
+}

--- a/SIKCore/src/test/java/com/sik/sikcore/string/StringUtilsTest.kt
+++ b/SIKCore/src/test/java/com/sik/sikcore/string/StringUtilsTest.kt
@@ -1,0 +1,30 @@
+package com.sik.sikcore.string
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class StringUtilsTest {
+    @Test
+    fun isBase64_valid() {
+        val valid = "SGVsbG8gd29ybGQ="
+        assertTrue(StringUtils.isBase64(valid))
+    }
+
+    @Test
+    fun isBase64_invalid() {
+        val invalid = "not base64*"
+        assertFalse(StringUtils.isBase64(invalid))
+    }
+
+    @Test
+    fun isHex_valid() {
+        val hex = "0A1B2C3D4E"
+        assertTrue(StringUtils.isHex(hex))
+    }
+
+    @Test
+    fun isHex_invalid() {
+        val invalid = "XYZ123"
+        assertFalse(StringUtils.isHex(invalid))
+    }
+}

--- a/SIKCore/src/test/java/com/sik/sikcore/thread/ThreadUtilsTest.kt
+++ b/SIKCore/src/test/java/com/sik/sikcore/thread/ThreadUtilsTest.kt
@@ -1,0 +1,40 @@
+package com.sik.sikcore.thread
+
+import android.app.Application
+import com.sik.sikcore.SIKCore
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE)
+class ThreadUtilsTest {
+
+    @Before
+    fun setup() {
+        val app = Application()
+        val field = SIKCore::class.java.getDeclaredField("application")
+        field.isAccessible = true
+        field.set(null, app)
+    }
+
+    @Test
+    fun runOnIO_executes() {
+        val latch = CountDownLatch(1)
+        ThreadUtils.runOnIO { latch.countDown() }
+        assertTrue(latch.await(1, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun cancelPreventsExecution() {
+        val latch = CountDownLatch(1)
+        val runId = ThreadUtils.runOnIODelayed(300) { latch.countDown() }
+        ThreadUtils.cancel(runId)
+        assertFalse(latch.await(600, TimeUnit.MILLISECONDS))
+    }
+}


### PR DESCRIPTION
## Summary
- enable running tests in SIKCore by adding JUnit/mockk/robolectric dependencies
- add sample unit tests for `StringUtils`
- add device root check tests
- verify `ThreadUtils` run/cancel behavior

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4452851c832e87b16ab0567bbe62