### PR TITLE
Add ByteArray and Set support for MMKV helpers

### DIFF
--- a/SIKCore/README.md
+++ b/SIKCore/README.md
@@ -285,6 +285,19 @@ fun saveData(key: String, value: Any)
 fun getData(key: String, isDeleteAfterGet: Boolean = true): Any?
 ```
 
+### [MMKV扩展函数](./src/main/java/com/sik/sikcore/extension/MMKVExtension.kt)
+
+```kotlin
+//保存数据，支持 Boolean、Float、Int、Long、String、ByteArray、Set<String>
+inline fun <reified T> MMKV.saveMMKVData(key: String, value: T)
+//获取数据
+inline fun <reified T> MMKV.getMMKVData(key: String, defaultValue: T): T
+//默认 mmkv 保存
+inline fun <reified T> String.saveMMKVData(value: T)
+//默认 mmkv 获取
+inline fun <reified T> String.getMMKVData(defaultValue: T): T
+```
+
 ### [日程管理工具类](https://github.com/SilverIceKey/SIKExtension/blob/master/SIKCore/src/main/java/com/sik/sikcore/date/ScheduleManagerUtils.kt)
 
 ```kotlin

--- a/SIKCore/src/main/java/com/sik/sikcore/extension/MMKVExtension.kt
+++ b/SIKCore/src/main/java/com/sik/sikcore/extension/MMKVExtension.kt
@@ -10,12 +10,14 @@ import com.tencent.mmkv.MMKV
  * @param value
  */
 inline fun <reified T> MMKV.saveMMKVData(key: String, value: T) {
-    when (T::class) {
-        Boolean::class -> this.encode(key, value as Boolean)
-        Float::class -> this.encode(key, value as Float)
-        Int::class -> this.encode(key, value as Int)
-        Long::class -> this.encode(key, value as Long)
-        String::class -> this.encode(key, value as String)
+    when (value) {
+        is Boolean -> this.encode(key, value)
+        is Float -> this.encode(key, value)
+        is Int -> this.encode(key, value)
+        is Long -> this.encode(key, value)
+        is String -> this.encode(key, value)
+        is ByteArray -> this.encode(key, value)
+        is Set<*> -> this.encode(key, value as Set<String>)
         else -> throw IllegalArgumentException("Unsupported type")
     }
 }
@@ -29,12 +31,14 @@ inline fun <reified T> MMKV.saveMMKVData(key: String, value: T) {
  * @return
  */
 inline fun <reified T> MMKV.getMMKVData(key: String, defaultValue: T): T {
-    return when (T::class) {
-        Boolean::class -> this.decodeBool(key, defaultValue as Boolean) as T
-        Float::class -> this.decodeFloat(key, defaultValue as Float) as T
-        Int::class -> this.decodeInt(key, defaultValue as Int) as T
-        Long::class -> this.decodeLong(key, defaultValue as Long) as T
-        String::class -> this.decodeString(key, defaultValue as String) as T
+    return when (defaultValue) {
+        is Boolean -> this.decodeBool(key, defaultValue) as T
+        is Float -> this.decodeFloat(key, defaultValue) as T
+        is Int -> this.decodeInt(key, defaultValue) as T
+        is Long -> this.decodeLong(key, defaultValue) as T
+        is String -> this.decodeString(key, defaultValue) as T
+        is ByteArray -> this.decodeBytes(key, defaultValue) as T
+        is Set<*> -> this.decodeStringSet(key, defaultValue as Set<String>) as T
         else -> throw IllegalArgumentException("Unsupported type")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 # Version
 GROUP_ID=com.github.silvericekey
 # ARTIFACT_ID=jitpack # config in your module
-VERSION=1.1.43
+VERSION=1.1.44
 # Gradle settings configured through the IDE *will override*
 # any settings specified in this file.
 # For more details on how to configure your build environment visit


### PR DESCRIPTION
## Summary
- expand `saveMMKVData` and `getMMKVData` to handle `ByteArray` and `Set<String>`
- document new types in `SIKCore/README.md`
- bump version to 1.1.44

## Testing
- `./gradlew :SIKCore:build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a44519534832e98e02ce27c1a71b4