### PR TITLE
Gracefully handle missing SIKCore native lib

### DIFF
--- a/SIKCore/src/main/java/com/sik/sikcore/SIKCore.kt
+++ b/SIKCore/src/main/java/com/sik/sikcore/SIKCore.kt
@@ -3,6 +3,7 @@ package com.sik.sikcore
 import android.app.Application
 import com.sik.sikcore.activity.ActivityTracker
 import com.tencent.mmkv.MMKV
+import org.slf4j.LoggerFactory
 
 /**
  * 扩展的初始化
@@ -10,6 +11,7 @@ import com.tencent.mmkv.MMKV
 object SIKCore {
     @Volatile
     private var application: Application? = null
+    private val logger = LoggerFactory.getLogger(SIKCore::class.java)
 
     /**
      * 初始化
@@ -18,7 +20,11 @@ object SIKCore {
         SIKCore.application = application
         application.registerActivityLifecycleCallbacks(ActivityTracker)
         MMKV.initialize(application)
-        System.loadLibrary("SIKCore")
+        try {
+            System.loadLibrary("SIKCore")
+        } catch (t: Throwable) {
+            logger.error("Failed to load native library SIKCore", t)
+        }
     }
 
     /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 # Version
 GROUP_ID=com.github.silvericekey
 # ARTIFACT_ID=jitpack # config in your module
-VERSION=1.1.43
+VERSION=1.1.44
 # Gradle settings configured through the IDE *will override*
 # any settings specified in this file.
 # For more details on how to configure your build environment visit


### PR DESCRIPTION
## Summary
- avoid crashing if the SIKCore native library is missing
- bump version to 1.1.44

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a444f8a60832ebcf86370d73f5dd9