### PR TITLE
Improve BeanUtils utilities

### DIFF
--- a/SIKCore/README.md
+++ b/SIKCore/README.md
@@ -252,6 +252,10 @@ fun colorIntToHex(@ColorInt colorInt: Int): String
 inline fun <reified T> copyData(source: Any, target: Any): T
 //使用反射进行相同字段的数据复制
 fun copyData(source: Any, target: Any)
+//根据getter/setter复制属性，可忽略null及指定字段
+fun copyProperties(source: Any, target: Any, ignoreNull: Boolean = false, vararg ignoreProperties: String)
+//批量复制属性到新的目标对象列表
+inline fun <reified T : Any> copyPropertiesList(sourceList: List<*>, ignoreNull: Boolean = false, vararg ignoreProperties: String): List<T>
 ```
 
 ### [转换工具类](https://github.com/SilverIceKey/SIKExtension/blob/master/SIKCore/src/main/java/com/sik/sikcore/data/ConvertUtils.kt)

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 # Version
 GROUP_ID=com.github.silvericekey
 # ARTIFACT_ID=jitpack # config in your module
-VERSION=1.1.44
+VERSION=1.1.45
 # Gradle settings configured through the IDE *will override*
 # any settings specified in this file.
 # For more details on how to configure your build environment visit


### PR DESCRIPTION
## Summary
- add skip logic for static/final fields in `BeanUtils.copyData`
- implement `copyProperties` and `copyPropertiesList`
- document new `BeanUtils` APIs
- bump version to 1.1.45

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a2c44a228832eaf928aefd71fac8b