### PR TITLE
Add basic unit tests

### DIFF
--- a/SIKCore/src/test/java/com/sik/sikcore/date/TimeUtilsTest.kt
+++ b/SIKCore/src/test/java/com/sik/sikcore/date/TimeUtilsTest.kt
@@ -1,0 +1,11 @@
+import com.sik.sikcore.date.TimeUtils
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TimeUtilsTest {
+    @Test
+    fun testLeapYear() {
+        assertEquals(true, TimeUtils.isLeapYear(2000))
+        assertEquals(false, TimeUtils.isLeapYear(1900))
+    }
+}

--- a/SIKCore/src/test/java/com/sik/sikcore/file/FileUtilsTest.kt
+++ b/SIKCore/src/test/java/com/sik/sikcore/file/FileUtilsTest.kt
@@ -1,0 +1,11 @@
+import com.sik.sikcore.file.FileUtils
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FileUtilsTest {
+    @Test
+    fun testFormatBytes() {
+        assertEquals("500 B", FileUtils.formatBytes(500))
+        assertEquals("1.000 KB", FileUtils.formatBytes(1024))
+    }
+}

--- a/SIKCore/src/test/java/com/sik/sikcore/zip/ZipUtilsTest.kt
+++ b/SIKCore/src/test/java/com/sik/sikcore/zip/ZipUtilsTest.kt
@@ -1,0 +1,19 @@
+import com.sik.sikcore.zip.ZipUtils
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class ZipUtilsTest {
+    @Test
+    fun testZipAndUnzip() {
+        val tempDir = createTempDir()
+        val file1 = File(tempDir, "file1.txt").apply { writeText("hello") }
+        val file2 = File(tempDir, "file2.txt").apply { writeText("world") }
+        val zipFile = File(tempDir, "archive.zip")
+        ZipUtils.zip(file1, file2, destFile = zipFile)
+        val destDir = File(tempDir, "unzipped")
+        ZipUtils.unzip(zipFile, destDir)
+        assertTrue(File(destDir, "file1.txt").exists())
+        assertTrue(File(destDir, "file2.txt").exists())
+    }
+}

--- a/SIKEncrypt/src/test/java/com/sik/sikencrypt/MessageDigestTest.kt
+++ b/SIKEncrypt/src/test/java/com/sik/sikencrypt/MessageDigestTest.kt
@@ -1,0 +1,31 @@
+import com.sik.sikencrypt.message_digest.MD5MessageDigest
+import com.sik.sikencrypt.message_digest.SHA256MessageDigest
+import com.sik.sikencrypt.message_digest.SM3MessageDigest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MessageDigestTest {
+    @Test
+    fun testMD5() {
+        val md5 = MD5MessageDigest()
+        assertEquals("900150983cd24fb0d6963f7d28e17f72", md5.digestToHex("abc".toByteArray()))
+    }
+
+    @Test
+    fun testSHA256() {
+        val sha256 = SHA256MessageDigest()
+        assertEquals(
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            sha256.digestToHex("abc".toByteArray())
+        )
+    }
+
+    @Test
+    fun testSM3() {
+        val sm3 = SM3MessageDigest()
+        assertEquals(
+            "66c7f0f462eeedd9d1f2d46bdc10e4e24167c4875cf2f7a2297da02b8f4ba8e0",
+            sm3.digestToHex("abc".toByteArray())
+        )
+    }
+}

--- a/SIKImage/build.gradle
+++ b/SIKImage/build.gradle
@@ -52,4 +52,10 @@ dependencies {
 
 
     compileOnly project(path: ':SIKCore')
+    // --- testing dependencies ---
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:1.8.20")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.8.20")
+    testImplementation("org.robolectric:robolectric:4.11.1")
+    testImplementation("io.mockk:mockk:1.13.5")
 }

--- a/SIKImage/src/test/java/com/sik/sikimage/ImageConvertUtilsTest.kt
+++ b/SIKImage/src/test/java/com/sik/sikimage/ImageConvertUtilsTest.kt
@@ -1,0 +1,17 @@
+import android.graphics.Bitmap
+import com.sik.sikimage.ImageConvertUtils
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class ImageConvertUtilsTest {
+    @Test
+    fun testBitmapBase64Conversion() {
+        val bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888)
+        val base64 = ImageConvertUtils.bitmapToBase64(bitmap)
+        val result = ImageConvertUtils.base64ToBitmap(base64)
+        assertNotNull(result)
+        assertEquals(bitmap.width, result!!.width)
+        assertEquals(bitmap.height, result.height)
+    }
+}

--- a/SIKImage/src/test/java/com/sik/sikimage/MatrixUtilsTest.kt
+++ b/SIKImage/src/test/java/com/sik/sikimage/MatrixUtilsTest.kt
@@ -1,0 +1,14 @@
+import android.graphics.Matrix
+import com.sik.sikimage.MatrixUtils
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MatrixUtilsTest {
+    @Test
+    fun testRotateMatrixToAngle() {
+        val matrix = Matrix()
+        MatrixUtils.rotateMatrixToAngle(matrix, 0f, 0f, 90f)
+        val angle = MatrixUtils.getRotationAngleFromMatrix(matrix)
+        assertEquals(90f, angle)
+    }
+}

--- a/SIKImage/src/test/java/com/sik/sikimage/QRCodeUtilsTest.kt
+++ b/SIKImage/src/test/java/com/sik/sikimage/QRCodeUtilsTest.kt
@@ -1,0 +1,13 @@
+import com.sik.sikimage.QRCodeUtils
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class QRCodeUtilsTest {
+    @Test
+    fun testCreateAndRead() {
+        val text = "hello"
+        val qr = QRCodeUtils.createQRCode(text, 200)
+        val result = QRCodeUtils.readQRCodeString(qr)
+        assertEquals(text, result)
+    }
+}

--- a/SIKMedia/build.gradle
+++ b/SIKMedia/build.gradle
@@ -41,4 +41,9 @@ dependencies {
     api("androidx.media3:media3-ui:$exoplayer")
     compileOnly 'androidx.core:core-ktx:1.8.0'
     compileOnly project(path: ':SIKCore')
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:1.8.20")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.8.20")
+    testImplementation("org.robolectric:robolectric:4.11.1")
+    testImplementation("io.mockk:mockk:1.13.5")
 }

--- a/SIKMedia/src/test/java/com/sik/sikmedia/AudioHelperTest.kt
+++ b/SIKMedia/src/test/java/com/sik/sikmedia/AudioHelperTest.kt
@@ -1,0 +1,19 @@
+import com.sik.sikmedia.AudioHelper
+import com.sik.sikmedia.AudioRecorderType
+import com.sik.sikmedia.AudioRecordImpl
+import com.sik.sikmedia.MediaRecorderImpl
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AudioHelperTest {
+    @Test
+    fun testSetRecorderType() {
+        AudioHelper.instance.setRecorderType(AudioRecorderType.MEDIA_RECORDER)
+        val field = AudioHelper::class.java.getDeclaredField("audioRecorder")
+        field.isAccessible = true
+        assertTrue(field.get(AudioHelper.instance) is MediaRecorderImpl)
+
+        AudioHelper.instance.setRecorderType(AudioRecorderType.AUDIO_RECORD)
+        assertTrue(field.get(AudioHelper.instance) is AudioRecordImpl)
+    }
+}

--- a/SIKNet/build.gradle
+++ b/SIKNet/build.gradle
@@ -46,4 +46,10 @@ dependencies {
     api('org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5')
 
     compileOnly project(path: ':SIKCore')
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:1.8.20")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.8.20")
+    testImplementation("org.robolectric:robolectric:4.11.1")
+    testImplementation("io.mockk:mockk:1.13.5")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 }

--- a/SIKNet/src/test/java/com/sik/siknet/HttpExtensionTest.kt
+++ b/SIKNet/src/test/java/com/sik/siknet/HttpExtensionTest.kt
@@ -1,0 +1,20 @@
+import com.sik.siknet.http.httpGet
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HttpExtensionTest {
+    data class Result(val msg: String)
+
+    @Test
+    fun testHttpGet() {
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setBody("\{"msg\":\"ok\"\}"))
+        server.start()
+        val url = server.url("/test").toString()
+        val result: Result = url.httpGet()
+        assertEquals("ok", result.msg)
+        server.shutdown()
+    }
+}

--- a/SIKSensors/build.gradle
+++ b/SIKSensors/build.gradle
@@ -36,4 +36,10 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation project(path: ':SIKCore')
     implementation project(path: ':SIKAndroid')
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:1.8.20")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.8.20")
+    testImplementation("org.robolectric:robolectric:4.11.1")
+    testImplementation("io.mockk:mockk:1.13.5")
+    testImplementation("org.mockito:mockito-core:5.6.0")
 }

--- a/SIKSensors/src/test/java/com/sik/siksensors/SensorMathUtilsTest.kt
+++ b/SIKSensors/src/test/java/com/sik/siksensors/SensorMathUtilsTest.kt
@@ -1,0 +1,19 @@
+import android.hardware.SensorEvent
+import com.sik.siksensors.SensorMathUtils
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.Mockito
+
+class SensorMathUtilsTest {
+    private fun mockEvent(vararg values: Float): SensorEvent {
+        val event = Mockito.mock(SensorEvent::class.java)
+        Mockito.`when`(event.values).thenReturn(values)
+        return event
+    }
+
+    @Test
+    fun testCalculateAccelerationMagnitude() {
+        val event = mockEvent(3f, 4f, 0f)
+        assertEquals(5f, SensorMathUtils.calculateAccelerationMagnitude(event))
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests across SIK modules
- include test dependencies for non-core modules
- provide sample tests for core utilities, image utils, net utilities, encrypt algorithms, media helper and sensor math

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ccd1ec450832e8d2a00bc0ef0afed