### PR TITLE
Fix AESEncrypt test naming

### DIFF
--- a/SIKEncrypt/src/test/java/com/sik/sikencrypt/AESEncryptTest.kt
+++ b/SIKEncrypt/src/test/java/com/sik/sikencrypt/AESEncryptTest.kt
@@ -7,15 +7,10 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.io.*
 import java.nio.charset.StandardCharsets
 import java.security.Security
 
-@RunWith(RobolectricTestRunner::class)
-@Config(sdk = [28], manifest = Config.NONE)
 class AESEncryptTest {
 
     private lateinit var config: IEncryptConfig


### PR DESCRIPTION
## Summary
- rename AESEncrypt.kt test file to AESEncryptTest.kt
- drop Robolectric annotations so it's a plain JUnit test

## Testing
- `./gradlew :SIKEncrypt:test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd78af054832e8cc138a71ae54b4b